### PR TITLE
add error handling code while loading xml failure

### DIFF
--- a/src/ePub/Loader/ZipFileLoader.php
+++ b/src/ePub/Loader/ZipFileLoader.php
@@ -36,6 +36,9 @@ class ZipFileLoader
         $this->resource = new ZipFileResource($file);
 
         $package = $this->resource ->getXML('META-INF/container.xml');
+        if ($package === false) {
+            throw new FileException();
+        }
 
         if (!$opfFile = (string) $package->rootfiles->rootfile['full-path']) {
             $ns = $package->getNamespaces();


### PR DESCRIPTION
`$this->resource->getXML()` 함수 내부에서 사용하는 `simplexml_load_string()` 에 대한 doc을 보면 아래와 같이 실패시에 `false`를 반환하도록 되어 있습니다.

```
 * @return SimpleXMLElement an object of class SimpleXMLElement with
 * properties containing the data held within the xml document, or <b>FALSE</b> on failure.
 ```

따라서 false 반환시에 밖에서 catch 할 수 있는 예외를 던져주어야 할 것 같습니다.