### PR TITLE
consumeNavMap nullCheck추가

### DIFF
--- a/src/ePub/Resource/NcxResource.php
+++ b/src/ePub/Resource/NcxResource.php
@@ -64,6 +64,10 @@ class NcxResource
     
     private function consumeNavMap($navMap, &$chapters)
     {
+        if (is_null($navMap->navPoint)) {
+            return;
+        }
+
         foreach ($navMap->navPoint as $navPoint) {
             $chapters[] = $this->consumeNavPoint($navPoint);
         }
@@ -80,5 +84,4 @@ class NcxResource
         
         return $chapter;
     }
-    
 }


### PR DESCRIPTION
`consumeNavMap`호출중에 navPoint가 없는경우 warning이 발생합니다.